### PR TITLE
use named import for EventEmitter to fix ESM version

### DIFF
--- a/src/CheapWatch.ts
+++ b/src/CheapWatch.ts
@@ -1,4 +1,4 @@
-import * as EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import { promisify } from 'util';
 


### PR DESCRIPTION
This project is so great, thank you! I've been using it for over a year without a hitch.

Running the ESM build currently fails with this error in Node 12 and 14:

```
class CheapWatch extends EventEmitter {
                         ^
TypeError: Class extends value [object Module] is not a constructor or null
```

It also causes a type error with `@types/node@14` as mentioned in #3. (but `@types/node@12` does not cause the type error)

The problem is that the `EventEmitter` class is available both as a default export and as a named export, but not as a namespace import (`* as`). The fix changes `import * as EventEmitter from 'events';` to `import { EventEmitter } from 'events';`.

I manually tested with Node 8/10/12/14 and this looks like this change works everywhere because `require('events') === require('events').EventEmitter`.

Here's how the dist files change:

```js
// CheapWatch.cjs.js

// before:
var EventEmitter = require('events');
class CheapWatch extends EventEmitter {

// after:
var events = require('events');
class CheapWatch extends events.EventEmitter {
```

```js
// CheapWatch.esm.js

// before:
import * as EventEmitter from 'events';
class CheapWatch extends EventEmitter {

// after:
import { EventEmitter } from 'events';
class CheapWatch extends EventEmitter {
```