### PR TITLE
fix(types): use `type` import

### DIFF
--- a/types/CheapWatch.d.ts
+++ b/types/CheapWatch.d.ts
@@ -1,17 +1,17 @@
-import * as EventEmitter from 'events';
-import * as fs from 'fs';
+import type { Stats } from 'fs';
+import type { EventEmitter } from 'events';
 
 export default class CheapWatch extends EventEmitter {
 	dir: string;
 	filter?: Filter;
 	watch: boolean;
 	debounce: number;
-	paths: Map<string, fs.Stats>;
+	paths: Map<string, Stats>;
 	constructor(data: object);
 	init(): Promise<void>;
 	close(): void;
 }
 
 interface Filter {
-	(file: { path: string; stats: fs.Stats }): Promise<boolean>;
+	(file: { path: string; stats: Stats }): Promise<boolean>;
 }


### PR DESCRIPTION
Without it, simple type-checking fails if you allow `node_module` library checks.

Doesn't affect anything with the actual code; just gives a hint to the TS compiler about what's going on.

***Before***

```
/cheap-watch@1.0.2/node_modules/cheap-watch/types/CheapWatch.d.ts:4:41 - error TS2507: Type 'typeof EventEmitter' is not a constructor function type.

4 export default class CheapWatch extends EventEmitter {
                                          ~~~~~~~~~~~~


Found 1 error.
```


***After***

_No errors_

---

Closes #3 without introducing source-code changes