### PR TITLE
feat: add mtime compare for path change

### DIFF
--- a/src/CheapWatch.ts
+++ b/src/CheapWatch.ts
@@ -126,6 +126,12 @@ export default class CheapWatch extends EventEmitter {
 					continue;
 				}
 				const isNew = !this.paths.has(path);
+				if (!isNew) {
+				  const lastStat = this.paths.get(path)
+				  if (String(lastStat.mtime) === String(stats.mtime)) {
+				    continue
+				  }
+				}
 				this.paths.set(path, stats);
 				if (path) {
 					this.emit('+', { path, stats, isNew });


### PR DESCRIPTION
I found it's better to compare `mtime` for stat and lastStat in `_enqueue`, if it's same, then skip.