### PR TITLE
fix: esm: runtime issue with importing EventEmitter: using named import

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
 	},
 	"homepage": "https://conduitry.dev/cheap-watch",
 	"devDependencies": {
+		"@rollup/plugin-typescript": "^8.2.3",
 		"@types/node": "^16",
 		"rollup": "^2.53.3",
-		"rollup-plugin-typescript2": "^0.30.0",
 		"typescript": "^4.3.5"
 	},
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
 	},
 	"homepage": "https://conduitry.dev/cheap-watch",
 	"devDependencies": {
-		"@types/node": "=8",
-		"rollup": "^2",
+		"@types/node": "^16",
+		"rollup": "^2.53.2",
 		"rollup-plugin-typescript2": "^0.30.0",
-		"typescript": "^3"
+		"typescript": "^4.3.5"
 	},
 	"scripts": {
 		"build": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	"homepage": "https://conduitry.dev/cheap-watch",
 	"devDependencies": {
 		"@types/node": "^16",
-		"rollup": "^2.53.2",
+		"rollup": "^2.53.3",
 		"rollup-plugin-typescript2": "^0.30.0",
 		"typescript": "^4.3.5"
 	},

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
 		"watch",
 		"watcher"
 	],
-	"main": "dist/CheapWatch.cjs.js",
-	"module": "dist/CheapWatch.esm.js",
+	"type": "module",
+	"main": "dist/CheapWatch.cjs",
+	"module": "dist/CheapWatch.mjs",
 	"types": "types/CheapWatch.d.ts",
 	"files": [
 		"dist",
@@ -30,10 +31,10 @@
 	},
 	"homepage": "https://conduitry.dev/cheap-watch",
 	"devDependencies": {
+		"@types/node": "=8",
 		"rollup": "^2",
-		"rollup-plugin-cheap-ts": "Conduitry/rollup-plugin-cheap-ts#semver:^1",
-		"typescript": "^3",
-		"@types/node": "=8"
+		"rollup-plugin-typescript2": "^0.30.0",
+		"typescript": "^3"
 	},
 	"scripts": {
 		"build": "rollup -c",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,16 +1,16 @@
-import cheap_ts from 'rollup-plugin-cheap-ts';
+import typescript2 from 'rollup-plugin-typescript2';
 
 export default {
 	input: './src/CheapWatch',
 	external: name => /^[a-z]/.test(name),
-	plugins: [cheap_ts()],
+	plugins: [typescript2()],
 	output: [
 		{
-			file: './dist/CheapWatch.cjs.js',
+			file: './dist/CheapWatch.cjs',
 			format: 'cjs',
 			sourcemap: true,
 			interop: false,
 		},
-		{ file: './dist/CheapWatch.esm.js', format: 'esm', sourcemap: true },
+		{ file: './dist/CheapWatch.mjs', format: 'es', sourcemap: true },
 	],
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,6 +10,7 @@ export default {
 			format: 'cjs',
 			sourcemap: true,
 			interop: false,
+			exports: 'auto'
 		},
 		{ file: './dist/CheapWatch.mjs', format: 'es', sourcemap: true },
 	],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,9 @@
-import typescript2 from 'rollup-plugin-typescript2';
+import typescript from '@rollup/plugin-typescript';
 
 export default {
 	input: './src/CheapWatch.ts',
 	external: name => /^[a-z]/.test(name),
-	plugins: [typescript2()],
+	plugins: [typescript()],
 	output: [
 		{
 			file: './dist/CheapWatch.cjs',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 import typescript2 from 'rollup-plugin-typescript2';
 
 export default {
-	input: './src/CheapWatch',
+	input: './src/CheapWatch.ts',
 	external: name => /^[a-z]/.test(name),
 	plugins: [typescript2()],
 	output: [

--- a/src/CheapWatch.ts
+++ b/src/CheapWatch.ts
@@ -1,4 +1,4 @@
-import * as EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import { promisify } from 'util';
 


### PR DESCRIPTION
fixes https://github.com/Conduitry/cheap-watch/issues/9

`dist/CheapWatch.cjs` & `dist/CheapWatch.mjs` are bundled in this PR. Feel free to convert back to original file names if preferred.

I'm also using the `rollup-plugin-typescript2` plugin to fix a build issue inside of a pnpm multirepo with `cheap-watch` installed as a git submodule.

The `dist/CheapWatch.mjs` top line is now `import { EventEmitter } from 'events';` instead of `import * as EventEmitter from 'events';`